### PR TITLE
Update CI workflow to run Node version check instead of forcing failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,5 @@ jobs:
         with:
           node-version: 18
 
-      - name: Force Failure
-        run: (exit 1)
+      - name: Node Version
+        run: node --version


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1459e7522088359eb3fd77fd84e5727194885ee5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->